### PR TITLE
Add useroffice URL environment params, remove hardcoded ALBA URL (#117)

### DIFF
--- a/src/app/authentication.service.ts
+++ b/src/app/authentication.service.ts
@@ -17,9 +17,8 @@ export class AuthenticationService {
   uoUserFromHashUrl = this.backendUrl_calipso + 'umbrella/wuo/';
   umbrellaLogoutUrl = this.backendUrl_calipso + 'umbrella/logout/';
   logoutUrl = this.backendUrl_calipso + 'logout/';
-  userUrl = this.backendUrl_calipso + 'users/$USERNAME/';
-  UOWebUrl = 'https://useroffice.cells.es/Welcome';
-
+  userUrl = this.backendUrl_calipso + 'user/$USERNAME/';
+  UOWebUrl = environment.auth.useroffice.url;
 
   constructor(private http: HttpClient, private router: Router) { }
 

--- a/src/environments/environment.docker.ts.example
+++ b/src/environments/environment.docker.ts.example
@@ -17,11 +17,15 @@ export const environment = {
     oidc: {
       enabled: false,
       url: 'http://example.com/oidc/authenticate'
+    },
+    useroffice: {
+      enabled: true,
+      url: 'https://USEROFFICE.URL'
     }
   },
   frontend: {
     url: 'http://web-front/',
     facilityLogo: 'assets/images/insert-logo-here.jpg'
   },
-  env : 'docker'
+  env: 'docker'
 };

--- a/src/environments/environment.prod.ts.example
+++ b/src/environments/environment.prod.ts.example
@@ -17,7 +17,11 @@ export const environment = {
     oidc: {
       enabled: false,
       url: 'http://example.com/oidc/authenticate'
-    }
+    },
+    useroffice: {
+      enabled: true,
+      url: 'https://USEROFFICE.URL'
+   }
   },
   frontend: {
     url: 'https://calipsofrontend.domain.tld/',

--- a/src/environments/environment.ts.example
+++ b/src/environments/environment.ts.example
@@ -22,7 +22,11 @@ export const environment = {
     oidc: {
       enabled: false,
       url: 'http://example.com/oidc/authenticate'
-    }
+    },
+	  useroffice: {
+      enabled: true,
+      url: 'https://USEROFFICE.URL'
+   }
   },
   frontend: {
     url: 'http://calipso-frontend/',


### PR DESCRIPTION
* Add useroffice URL, remove hardcoded ALBA URL

As per a discussion with Aidan and Alex, we are
removing the hardcoded UOWebUrl (previously set
to 'https://useroffice.cells.es/Welcome') and
allowing this to be configurable via the frontend
environment.ts files.

The README will also need to be updated.

Currently, the 'enabled' boolean doesn't do anything.

* Add new useroffice stanza to remaining env files